### PR TITLE
Update Historic spritesheet URL

### DIFF
--- a/index-layeroptions-tegola-ohm-full.js
+++ b/index-layeroptions-tegola-ohm-full.js
@@ -21,7 +21,7 @@ const MAPSTYLE_FULLCOLOR = {
       "tileSize": 256
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet",
+  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
   "glyphs": "https://openhistoricalmap.github.io/map-styles/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/index-layeroptions-tegola-ohm-white25.js
+++ b/index-layeroptions-tegola-ohm-white25.js
@@ -21,7 +21,7 @@ const MAPSTYLE_LIGHT = {
       "tileSize": 256
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet",
+  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
   "glyphs": "https://openhistoricalmap.github.io/map-styles/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/index-layeroptions-tegola-ohm-white50.js
+++ b/index-layeroptions-tegola-ohm-white50.js
@@ -21,7 +21,7 @@ const MAPSTYLE_LIGHTEST = {
       "tileSize": 256
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/ohm_spritezero_spritesheet",
+  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
   "glyphs": "https://openhistoricalmap.github.io/map-styles/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/mapstyle.js
+++ b/mapstyle.js
@@ -10,7 +10,7 @@ const OHM_MAP_STYLE = {
       ],
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/ohm_timeslider_tegola/osm_tegola_spritesheet",
+  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
   "glyphs": "https://go-spatial.github.io/carto-assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
OpenHistoricalMap/map-styles#29 moved the Historic stylesheet to a different folder, affecting the URL to the stylesheet’s spritesheet, which many other styles happen to reuse.