### PR TITLE
Update spritesheet, fontstack URLs to production

### DIFF
--- a/index-layeroptions-tegola-ohm-full.js
+++ b/index-layeroptions-tegola-ohm-full.js
@@ -21,8 +21,8 @@ const MAPSTYLE_FULLCOLOR = {
       "tileSize": 256
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
-  "glyphs": "https://openhistoricalmap.github.io/map-styles/fonts/{fontstack}/{range}.pbf",
+  "sprite": "https://www.openhistoricalmap.org/map-styles/main/main_spritesheet",
+  "glyphs": "https://www.openhistoricalmap.org/map-styles/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/index-layeroptions-tegola-ohm-white25.js
+++ b/index-layeroptions-tegola-ohm-white25.js
@@ -21,8 +21,8 @@ const MAPSTYLE_LIGHT = {
       "tileSize": 256
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
-  "glyphs": "https://openhistoricalmap.github.io/map-styles/fonts/{fontstack}/{range}.pbf",
+  "sprite": "https://www.openhistoricalmap.org/map-styles/main/main_spritesheet",
+  "glyphs": "https://www.openhistoricalmap.org/map-styles/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/index-layeroptions-tegola-ohm-white50.js
+++ b/index-layeroptions-tegola-ohm-white50.js
@@ -21,8 +21,8 @@ const MAPSTYLE_LIGHTEST = {
       "tileSize": 256
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
-  "glyphs": "https://openhistoricalmap.github.io/map-styles/fonts/{fontstack}/{range}.pbf",
+  "sprite": "https://www.openhistoricalmap.org/map-styles/main/main_spritesheet",
+  "glyphs": "https://www.openhistoricalmap.org/map-styles/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/mapstyle.js
+++ b/mapstyle.js
@@ -10,7 +10,7 @@ const OHM_MAP_STYLE = {
       ],
     }
   },
-  "sprite": "https://openhistoricalmap.github.io/map-styles/main/main_spritesheet",
+  "sprite": "https://www.openhistoricalmap.org/map-styles/main/main_spritesheet",
   "glyphs": "https://go-spatial.github.io/carto-assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
The styles have moved again: https://github.com/OpenHistoricalMap/issues/issues/827#issuecomment-2174577539.